### PR TITLE
Remove unused getPreviousRotation

### DIFF
--- a/app/Http/Controllers/FuelIndexController.php
+++ b/app/Http/Controllers/FuelIndexController.php
@@ -186,12 +186,4 @@ class FuelIndexController extends Controller
         ])->with('success', 'Relevé mis à jour avec succès.');
     }
 
-    private function getPreviousRotation($rotation)
-    {
-        return match ($rotation) {
-            '6-14' => '22-6',
-            '14-22' => '6-14',
-            '22-6' => '14-22',
-        };
-    }
 }


### PR DESCRIPTION
## Summary
- clean up FuelIndex controller

## Testing
- `composer install --no-interaction --no-progress`
- `php artisan migrate --force --no-interaction`
- `./vendor/bin/pest` *(fails: The user is not authenticated / Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6e13e0508323a0c435f60b44d830