### PR TITLE
Tri alphabétique des entités

### DIFF
--- a/app/Http/Controllers/BalanceTopupController.php
+++ b/app/Http/Controllers/BalanceTopupController.php
@@ -21,7 +21,9 @@ class BalanceTopupController extends Controller
 
     public function create()
     {
-        $clients = Client::where('station_id', session('selected_station_id'))->get();
+        $clients = Client::where('station_id', session('selected_station_id'))
+            ->orderBy('name')
+            ->get();
 
         return view('balance_topups.create', compact('clients'));
     }
@@ -69,7 +71,9 @@ class BalanceTopupController extends Controller
 
     public function edit(BalanceTopup $balanceTopup)
     {
-        $clients = Client::where('station_id', session('selected_station_id'))->get();
+        $clients = Client::where('station_id', session('selected_station_id'))
+            ->orderBy('name')
+            ->get();
 
         return view('balance_topups.edit', compact('balanceTopup', 'clients'));
     }

--- a/app/Http/Controllers/BalanceUsageController.php
+++ b/app/Http/Controllers/BalanceUsageController.php
@@ -21,7 +21,9 @@ class BalanceUsageController extends Controller
 
     public function create()
     {
-        $clients = Client::where('station_id', session('selected_station_id'))->get();
+        $clients = Client::where('station_id', session('selected_station_id'))
+            ->orderBy('name')
+            ->get();
 
         return view('balance_usages.create', compact('clients'));
     }
@@ -46,7 +48,9 @@ class BalanceUsageController extends Controller
 
     public function edit(BalanceUsage $balanceUsage)
     {
-        $clients = Client::where('station_id', session('selected_station_id'))->get();
+        $clients = Client::where('station_id', session('selected_station_id'))
+            ->orderBy('name')
+            ->get();
 
         return view('balance_usages.edit', compact('balanceUsage', 'clients'));
     }

--- a/app/Http/Controllers/ClientBalanceController.php
+++ b/app/Http/Controllers/ClientBalanceController.php
@@ -13,6 +13,7 @@ class ClientBalanceController extends Controller
 
         $clients = Client::with(['balanceTopups', 'balanceUsages'])
             ->where('station_id', $stationId)
+            ->orderBy('name')
             ->get()
             ->filter(function ($client) {
                 $totalRecharges = $client->balanceTopups->sum('amount');

--- a/app/Http/Controllers/CreditPaymentController.php
+++ b/app/Http/Controllers/CreditPaymentController.php
@@ -25,7 +25,9 @@ class CreditPaymentController extends Controller
     {
         $stationId = session('selected_station_id');
 
-        $clients = Client::where('station_id', $stationId)->get();
+        $clients = Client::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
 
         return view('credit_payments.create', compact('clients'));
     }
@@ -62,7 +64,9 @@ class CreditPaymentController extends Controller
     {
         $stationId = session('selected_station_id');
 
-        $clients = Client::where('station_id', $stationId)->get();
+        $clients = Client::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
 
         return view('credit_payments.edit', compact('creditPayment', 'clients'));
     }

--- a/app/Http/Controllers/CreditTopupController.php
+++ b/app/Http/Controllers/CreditTopupController.php
@@ -27,7 +27,9 @@ class CreditTopupController extends Controller
 
     public function create()
     {
-        $clients = Client::where('station_id', session('selected_station_id'))->get();
+        $clients = Client::where('station_id', session('selected_station_id'))
+            ->orderBy('name')
+            ->get();
 
         return view('credit_topups.create', compact('clients'));
     }
@@ -76,7 +78,9 @@ class CreditTopupController extends Controller
 
     public function edit(CreditTopup $creditTopup)
     {
-        $clients = Client::where('station_id', session('selected_station_id'))->get();
+        $clients = Client::where('station_id', session('selected_station_id'))
+            ->orderBy('name')
+            ->get();
 
         return view('credit_topups.edit', compact('creditTopup', 'clients'));
     }

--- a/app/Http/Controllers/ExpenseCategoryController.php
+++ b/app/Http/Controllers/ExpenseCategoryController.php
@@ -11,7 +11,9 @@ class ExpenseCategoryController extends Controller
     {
         $stationId = session('selected_station_id');
 
-        $categories = ExpenseCategory::where('station_id', $stationId)->paginate(10);
+        $categories = ExpenseCategory::where('station_id', $stationId)
+            ->orderBy('name')
+            ->paginate(10);
 
         return view('expense_categories.index', compact('categories'))->with('i', ($request->input('page', 1) - 1) * 10);
     }

--- a/app/Http/Controllers/FuelReceptionController.php
+++ b/app/Http/Controllers/FuelReceptionController.php
@@ -45,9 +45,15 @@ class FuelReceptionController extends Controller
 
         $stationId = session('selected_station_id');
 
-        $tanks = Tank::where('station_id', $stationId)->get();
-        $transporters = Transporter::where('station_id', $stationId)->get();
-        $drivers = Driver::where('station_id', $stationId)->get();
+        $tanks = Tank::where('station_id', $stationId)
+            ->orderBy('code')
+            ->get();
+        $transporters = Transporter::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
+        $drivers = Driver::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
 
         return view('fuel_receptions.create', compact('tanks', 'transporters', 'drivers'));
     }
@@ -215,9 +221,15 @@ class FuelReceptionController extends Controller
         $stationId = session('selected_station_id');
 
         $reception = FuelReception::with(['lines', 'station', 'transporter', 'driver'])->findOrFail($id);
-        $tanks = Tank::where('station_id', $stationId)->get();
-        $transporters = Transporter::where('station_id', $stationId)->get();
-        $drivers = Driver::where('station_id', $stationId)->get();
+        $tanks = Tank::where('station_id', $stationId)
+            ->orderBy('code')
+            ->get();
+        $transporters = Transporter::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
+        $drivers = Driver::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
 
         return view('fuel_receptions.edit', compact('reception', 'tanks', 'transporters', 'drivers'));
     }

--- a/app/Http/Controllers/LubricantReceptionBatchController.php
+++ b/app/Http/Controllers/LubricantReceptionBatchController.php
@@ -60,13 +60,16 @@ class LubricantReceptionBatchController extends Controller
 
         $categories = StationCategory::where('station_id', $stationId)
             ->whereIn('type', ['lubrifiant'])
+            ->orderBy('name')
             ->get();
 
         /*$stationProducts = StationProduct::whereIn('category_id', $categories)
             ->with('packagings')
             ->get();*/
 
-        $suppliers = Supplier::where('station_id', $stationId)->get();
+        $suppliers = Supplier::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
 
         return view('lubricant_reception_batches.create', compact('categories', 'suppliers'));
     }
@@ -168,13 +171,17 @@ class LubricantReceptionBatchController extends Controller
 
         $categories = StationCategory::where('station_id', $stationId)
             ->whereIn('type', ['lubrifiant', 'pea', 'gaz', 'lampe'])
+            ->orderBy('name')
             ->pluck('id');
 
         $stationProducts = StationProduct::whereIn('category_id', $categories)
             ->with('productPackagings.packaging') // ← on utilise bien le modèle pivot avec ses relations
+            ->orderBy('name')
             ->get();
 
-        $suppliers = Supplier::where('station_id', $stationId)->get();
+        $suppliers = Supplier::where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
 
         $batch->load('receptions.product', 'receptions.packaging.packaging'); // ← pour la vue
 

--- a/app/Http/Controllers/PumpController.php
+++ b/app/Http/Controllers/PumpController.php
@@ -11,7 +11,10 @@ class PumpController extends Controller
     public function index()
     {
         $stationId = session('selected_station_id');
-        $pumps = Pump::with('tank')->where('station_id', $stationId)->get();
+        $pumps = Pump::with('tank')
+            ->where('station_id', $stationId)
+            ->orderBy('name')
+            ->get();
 
         return view('pumps.index', compact('pumps'));
     }

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -22,7 +22,7 @@ class RoleController extends Controller
 
     public function index(Request $request): View
     {
-        $roles = Role::orderBy('id', 'DESC')->paginate(5);
+        $roles = Role::orderBy('name')->paginate(5);
 
         return view('roles.index', compact('roles'))
             ->with('i', ($request->input('page', 1) - 1) * 5);

--- a/app/Http/Controllers/StationController.php
+++ b/app/Http/Controllers/StationController.php
@@ -16,7 +16,7 @@ class StationController extends Controller
     public function index(Request $request)
     {
 
-        $data = Station::latest()->paginate(5);
+        $data = Station::orderBy('name')->paginate(5);
 
         return view('stations.index', compact('data'))
             ->with('i', ($request->input('page', 1) - 1) * 5);

--- a/app/Http/Controllers/StationUserController.php
+++ b/app/Http/Controllers/StationUserController.php
@@ -10,12 +10,15 @@ class StationUserController extends Controller
 {
     public function index()
     {
-        $stations = Station::all();
+        $stations = Station::orderBy('name')->get();
 
         // Exclure les super utilisateurs et charger les relations stations
         $users = User::whereDoesntHave('roles', function ($query) {
             $query->whereIn('name', ['Super Gestionnaire', 'super-admin']);
-        })->with('stations')->get();
+        })
+            ->with('stations')
+            ->orderBy('name')
+            ->get();
 
         return view('stations.associate', compact('stations', 'users'));
     }

--- a/app/Http/Controllers/TankController.php
+++ b/app/Http/Controllers/TankController.php
@@ -17,6 +17,7 @@ class TankController extends Controller
 
         $tanks = Tank::with(['station', 'product', 'stock'])
             ->where('station_id', $stationId)
+            ->orderBy('code')
             ->get();
 
         return view('tanks.index', compact('tanks'));

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -22,7 +22,7 @@ class UserController extends Controller
      */
     public function index(Request $request): View
     {
-        $data = User::latest()->paginate(5);
+        $data = User::orderBy('name')->paginate(5);
 
         return view('users.index', compact('data'))
             ->with('i', ($request->input('page', 1) - 1) * 5);


### PR DESCRIPTION
## Summary
- trie les rubriques de dépenses par nom
- tri par nom pour les stations
- tri alphabétique pour les rôles et utilisateurs
- divers formulaires listant des entités sont triés par nom

## Testing
- `composer install --no-interaction --no-progress`
- `php artisan test` *(échoue : database.sqlite manquant)*

------
https://chatgpt.com/codex/tasks/task_e_687f75056628832388c6b73fcd816aba