### PR TITLE
Cleaned comments and added docblocks

### DIFF
--- a/app/Http/Controllers/BalanceTopupController.php
+++ b/app/Http/Controllers/BalanceTopupController.php
@@ -50,6 +50,13 @@ class BalanceTopupController extends Controller
         return redirect()->route('balances.summary')->with('success', 'Recharge ajoutée.');
     }
 
+    /**
+     * Resolve the entity ID from a request value.
+     *
+     * @param class-string $model     Model class to use for lookup
+     * @param string|null  $value     ID or name provided by the user
+     * @param int          $stationId Current station identifier
+     */
     private function resolveEntityId(string $model, ?string $value, int $stationId): ?int
     {
         if (empty($value)) {

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -4,5 +4,4 @@ namespace App\Http\Controllers;
 
 abstract class Controller
 {
-    //
 }

--- a/app/Http/Controllers/FuelReceptionLineController.php
+++ b/app/Http/Controllers/FuelReceptionLineController.php
@@ -12,7 +12,6 @@ class FuelReceptionLineController extends Controller
      */
     public function index()
     {
-        //
     }
 
     /**
@@ -20,7 +19,6 @@ class FuelReceptionLineController extends Controller
      */
     public function create()
     {
-        //
     }
 
     /**
@@ -28,7 +26,6 @@ class FuelReceptionLineController extends Controller
      */
     public function store(Request $request)
     {
-        //
     }
 
     /**
@@ -36,7 +33,6 @@ class FuelReceptionLineController extends Controller
      */
     public function show(FuelReceptionLine $fuelReceptionLine)
     {
-        //
     }
 
     /**
@@ -44,7 +40,6 @@ class FuelReceptionLineController extends Controller
      */
     public function edit(FuelReceptionLine $fuelReceptionLine)
     {
-        //
     }
 
     /**
@@ -52,7 +47,6 @@ class FuelReceptionLineController extends Controller
      */
     public function update(Request $request, FuelReceptionLine $fuelReceptionLine)
     {
-        //
     }
 
     /**
@@ -60,6 +54,5 @@ class FuelReceptionLineController extends Controller
      */
     public function destroy(FuelReceptionLine $fuelReceptionLine)
     {
-        //
     }
 }

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -19,8 +19,9 @@ class PaymentController extends Controller
 
 
 
-    // Dans PaymentController.php
-
+    /**
+     * Enregistre un paiement pour la facture spécifiée.
+     */
     public function store(Request $request, $invoiceId)
     {
         // Validation des données
@@ -57,6 +58,9 @@ class PaymentController extends Controller
     }
 
 
+    /**
+     * Supprime un paiement existant et met à jour la facture associée.
+     */
     public function destroy($paymentId)
     {
         // Trouver le paiement à supprimer

--- a/app/Models/LubricantReception.php
+++ b/app/Models/LubricantReception.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-// tu avais oublié d'importer ce modèle ici
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 

--- a/app/Models/PurchaseInvoice.php
+++ b/app/Models/PurchaseInvoice.php
@@ -35,8 +35,6 @@ class PurchaseInvoice extends Model
         return $this->hasMany(Payment::class, 'invoice_id');
     }
 
-    // Dans le modèle Invoice.php
-
     public function updateAmounts()
     {
         // Calcule le montant payé jusqu'à présent

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,7 +12,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,47 +1,9 @@
 <?php
 
-/*
-|--------------------------------------------------------------------------
-| Test Case
-|--------------------------------------------------------------------------
-|
-| The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
-| need to change it using the "pest()" function to bind a different classes or traits.
-|
-*/
-
 pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
 
-/*
-|--------------------------------------------------------------------------
-| Expectations
-|--------------------------------------------------------------------------
-|
-| When you're writing tests, you often need to check that values meet certain conditions. The
-| "expect()" function gives you access to a set of "expectations" methods that you can use
-| to assert different things. Of course, you may extend the Expectation API at any time.
-|
-*/
-
 expect()->extend('toBeOne', function () {
     return $this->toBe(1);
 });
-
-/*
-|--------------------------------------------------------------------------
-| Functions
-|--------------------------------------------------------------------------
-|
-| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
-| project that you don't want to repeat in every file. Here you can also expose helpers as
-| global functions to help you to reduce the number of lines of code in your test files.
-|
-*/
-
-function something()
-{
-    // ..
-}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,4 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
 }


### PR DESCRIPTION
## Summary
- remove stray comment markers and unused comments
- document `store` and `destroy` in `PaymentController`
- describe `resolveEntityId` in `BalanceTopupController`
- trim default comments from tests

## Testing
- `composer install --no-interaction`
- `./vendor/bin/pest` *(fails: Database file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687f7d348d548323bacb42f6cd252f21