### PR TITLE
Restrict edits after validation across controllers

### DIFF
--- a/app/Http/Controllers/BalanceUsageController.php
+++ b/app/Http/Controllers/BalanceUsageController.php
@@ -4,10 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Models\BalanceUsage;
 use App\Models\Client;
+use App\Models\DailyRevenueValidation;
+use App\Models\ModificationLog;
+use App\Traits\ValidatesRotation;
 use Illuminate\Http\Request;
 
 class BalanceUsageController extends Controller
 {
+    use ValidatesRotation;
     public function index()
     {
         $stationId = session('selected_station_id');
@@ -64,15 +68,50 @@ class BalanceUsageController extends Controller
             'rotation' => 'required|in:6-14,14-22,22-6',
             'notes' => 'nullable|string',
         ]);
+        $isValidated = DailyRevenueValidation::where('station_id', $balanceUsage->station_id)
+            ->where('date', $balanceUsage->date)
+            ->where('rotation', $balanceUsage->rotation)
+            ->exists();
 
+        if (! $this->modificationAllowed(
+            $balanceUsage->station_id,
+            $balanceUsage->date,
+            $balanceUsage->rotation
+        )) {
+            return redirect()->route('balance-usages.index')->with('error', 'Cette rotation a déjà été validée. Modification impossible.');
+        }
+
+        $before = $balanceUsage->getOriginal();
         $balanceUsage->update($data);
+
+        if ($isValidated) {
+            $this->logOverride($balanceUsage, $before, $balanceUsage->getAttributes());
+        }
 
         return redirect()->route('balance-usages.index')->with('success', 'Avoir servi mis à jour avec succès.');
     }
 
     public function destroy(BalanceUsage $balanceUsage)
     {
+        $isValidated = DailyRevenueValidation::where('station_id', $balanceUsage->station_id)
+            ->where('date', $balanceUsage->date)
+            ->where('rotation', $balanceUsage->rotation)
+            ->exists();
+
+        if (! $this->modificationAllowed(
+            $balanceUsage->station_id,
+            $balanceUsage->date,
+            $balanceUsage->rotation
+        )) {
+            return back()->with('error', 'Cette rotation a déjà été validée. Suppression impossible.');
+        }
+
+        $before = $balanceUsage->getOriginal();
         $balanceUsage->delete();
+
+        if ($isValidated) {
+            $this->logOverride($balanceUsage, $before, []);
+        }
 
         return back()->with('success', 'Avoir servi supprimé avec succès.');
     }

--- a/app/Models/ModificationLog.php
+++ b/app/Models/ModificationLog.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ModificationLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'model_type',
+        'model_id',
+        'changes',
+    ];
+
+    protected $casts = [
+        'changes' => 'array',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Traits/ValidatesRotation.php
+++ b/app/Traits/ValidatesRotation.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\DailyRevenueValidation;
+use App\Models\ModificationLog;
+
+trait ValidatesRotation
+{
+    protected function modificationAllowed(int $stationId, $date, $rotation): bool
+    {
+        $isValidated = DailyRevenueValidation::where('station_id', $stationId)
+            ->where('date', $date)
+            ->where('rotation', $rotation)
+            ->exists();
+
+        $user = auth()->user();
+        $canOverride = $user && $user->hasAnyRole([
+            'Super Gestionnaire',
+            'Gestionnaire Multi-Sites',
+            'Gestionnaire de Site Unique',
+        ]);
+
+        return ! $isValidated || $canOverride;
+    }
+
+    protected function logOverride($model, array $before, array $after): void
+    {
+        ModificationLog::create([
+            'user_id' => auth()->id(),
+            'model_type' => get_class($model),
+            'model_id' => $model->id,
+            'changes' => [
+                'before' => $before,
+                'after' => $after,
+            ],
+        ]);
+    }
+}

--- a/database/migrations/2025_07_22_125103_create_modification_logs_table.php
+++ b/database/migrations/2025_07_22_125103_create_modification_logs_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('modification_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+            $table->json('changes');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('modification_logs');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
## Summary
- centralize rotation validation logic via `ValidatesRotation` trait
- apply trait to financial controllers and log changes to `ModificationLog`
- set PHPUnit to use SQLite memory database

## Testing
- `composer install`
- `npm install`
- `npm run build`
- `php artisan key:generate`
- `php artisan test` *(fails: 3 tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f88a7c48883238555a89e13034bab